### PR TITLE
ci(vss): auto-extract Gradle version number ffg upgrade

### DIFF
--- a/.github/workflows/vss-integration.yml
+++ b/.github/workflows/vss-integration.yml
@@ -62,9 +62,16 @@ jobs:
           # Print Info
           java -version
           gradle --version
+          
+          GRADLE_VERSION=$(gradle --version | awk '/^Gradle/ {print $2}' | head -1)
+          if [ -z "$GRADLE_VERSION" ]; then
+            echo "Error: Failed to extract Gradle version." >&2
+            exit 1
+          fi
+          echo "Extracted Gradle Version: $GRADLE_VERSION"
 
           cd vss-server/java
-          gradle wrapper --gradle-version 8.1.1
+          gradle wrapper --gradle-version $GRADLE_VERSION
           ./gradlew --version
           ./gradlew build
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1591,12 +1591,12 @@ fn build_with_store_internal(
 	};
 
 	let (stop_sender, _) = tokio::sync::watch::channel(());
-	let (event_handling_stopped_sender, _) = tokio::sync::watch::channel(());
+	let background_processor_task = Mutex::new(None);
 
 	Ok(Node {
 		runtime,
 		stop_sender,
-		event_handling_stopped_sender,
+		background_processor_task,
 		config,
 		wallet,
 		chain_source,

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -40,7 +40,7 @@ use std::time::{Duration, Instant};
 
 const BDK_ELECTRUM_CLIENT_BATCH_SIZE: usize = 5;
 const ELECTRUM_CLIENT_NUM_RETRIES: u8 = 3;
-const ELECTRUM_CLIENT_TIMEOUT_SECS: u8 = 20;
+const ELECTRUM_CLIENT_TIMEOUT_SECS: u8 = 10;
 
 pub(crate) struct ElectrumRuntimeClient {
 	electrum_client: Arc<ElectrumClient>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,10 +65,13 @@ pub(crate) const NODE_ANN_BCAST_INTERVAL: Duration = Duration::from_secs(60 * 60
 pub(crate) const WALLET_SYNC_INTERVAL_MINIMUM_SECS: u64 = 10;
 
 // The timeout after which we abort a wallet syncing operation.
-pub(crate) const BDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 90;
+pub(crate) const BDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 20;
 
 // The timeout after which we abort a wallet syncing operation.
-pub(crate) const LDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 30;
+pub(crate) const LDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 10;
+
+// The timeout after which we give up waiting on LDK's event handler to exit on shutdown.
+pub(crate) const LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
 
 // The timeout after which we abort a fee rate cache update operation.
 pub(crate) const FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS: u64 = 5;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ uniffi::include_scaffolding!("ldk_node");
 pub struct Node {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	stop_sender: tokio::sync::watch::Sender<()>,
-	event_handling_stopped_sender: tokio::sync::watch::Sender<()>,
+	background_processor_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 	config: Arc<Config>,
 	wallet: Arc<Wallet>,
 	chain_source: Arc<ChainSource>,
@@ -579,8 +579,7 @@ impl Node {
 		};
 
 		let background_stop_logger = Arc::clone(&self.logger);
-		let event_handling_stopped_sender = self.event_handling_stopped_sender.clone();
-		runtime.spawn(async move {
+		let handle = runtime.spawn(async move {
 			process_events_async(
 				background_persister,
 				|e| background_event_handler.handle_event(e),
@@ -601,19 +600,9 @@ impl Node {
 				panic!("Failed to process events");
 			});
 			log_debug!(background_stop_logger, "Events processing stopped.",);
-
-			match event_handling_stopped_sender.send(()) {
-				Ok(_) => (),
-				Err(e) => {
-					log_error!(
-						background_stop_logger,
-						"Failed to send 'events handling stopped' signal. This should never happen: {}",
-						e
-						);
-					debug_assert!(false);
-				},
-			}
 		});
+		debug_assert!(self.background_processor_task.lock().unwrap().is_none());
+		*self.background_processor_task.lock().unwrap() = Some(handle);
 
 		if let Some(liquidity_source) = self.liquidity_source.as_ref() {
 			let mut stop_liquidity_handler = self.stop_sender.subscribe();
@@ -670,39 +659,42 @@ impl Node {
 		// Disconnect all peers.
 		self.peer_manager.disconnect_all_peers();
 
-		// Wait until event handling stopped, at least until a timeout is reached.
-		let event_handling_stopped_logger = Arc::clone(&self.logger);
-		let mut event_handling_stopped_receiver = self.event_handling_stopped_sender.subscribe();
+		// Stop any runtime-dependant chain sources.
+		self.chain_source.stop();
 
-		let timeout_res = tokio::task::block_in_place(move || {
-			runtime.block_on(async {
-				tokio::time::timeout(
-					Duration::from_secs(LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS),
-					event_handling_stopped_receiver.changed(),
-				)
-				.await
-			})
-		});
+		// Wait until background processing stopped, at least until a timeout is reached.
+		if let Some(background_processor_task) =
+			self.background_processor_task.lock().unwrap().take()
+		{
+			let abort_handle = background_processor_task.abort_handle();
+			let timeout_res = tokio::task::block_in_place(move || {
+				runtime.block_on(async {
+					tokio::time::timeout(
+						Duration::from_secs(LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS),
+						background_processor_task,
+					)
+					.await
+				})
+			});
 
-		match timeout_res {
-			Ok(stop_res) => match stop_res {
-				Ok(()) => {},
-				Err(e) => {
-					log_error!(
-						event_handling_stopped_logger,
-						"Stopping event handling failed. This should never happen: {}",
-						e
-					);
-					panic!("Stopping event handling failed. This should never happen.");
+			match timeout_res {
+				Ok(stop_res) => match stop_res {
+					Ok(()) => {},
+					Err(e) => {
+						abort_handle.abort();
+						log_error!(
+							self.logger,
+							"Stopping event handling failed. This should never happen: {}",
+							e
+						);
+						panic!("Stopping event handling failed. This should never happen.");
+					},
 				},
-			},
-			Err(e) => {
-				log_error!(
-					event_handling_stopped_logger,
-					"Stopping event handling timed out: {}",
-					e
-				);
-			},
+				Err(e) => {
+					abort_handle.abort();
+					log_error!(self.logger, "Stopping event handling timed out: {}", e);
+				},
+			}
 		}
 
 		#[cfg(tokio_unstable)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,9 @@ pub use builder::NodeBuilder as Builder;
 
 use chain::ChainSource;
 use config::{
-	default_user_config, may_announce_channel, ChannelConfig, Config, NODE_ANN_BCAST_INTERVAL,
-	PEER_RECONNECTION_INTERVAL, RGS_SYNC_INTERVAL,
+	default_user_config, may_announce_channel, ChannelConfig, Config,
+	LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS, NODE_ANN_BCAST_INTERVAL, PEER_RECONNECTION_INTERVAL,
+	RGS_SYNC_INTERVAL,
 };
 use connection::ConnectionManager;
 use event::{EventHandler, EventQueue};
@@ -673,13 +674,10 @@ impl Node {
 		let event_handling_stopped_logger = Arc::clone(&self.logger);
 		let mut event_handling_stopped_receiver = self.event_handling_stopped_sender.subscribe();
 
-		// FIXME: For now, we wait up to 100 secs (BDK_WALLET_SYNC_TIMEOUT_SECS + 10) to allow
-		// event handling to exit gracefully even if it was blocked on the BDK wallet syncing. We
-		// should drop this considerably post upgrading to BDK 1.0.
 		let timeout_res = tokio::task::block_in_place(move || {
 			runtime.block_on(async {
 				tokio::time::timeout(
-					Duration::from_secs(100),
+					Duration::from_secs(LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS),
 					event_handling_stopped_receiver.changed(),
 				)
 				.await


### PR DESCRIPTION
## What this PR does
- Extract and use Gradle version instead hard-coded value.
- Pending VSS-Server PR [#50](https://github.com/lightningdevkit/vss-server/pull/50) so we can checkout the latest repository with the fix introduced.

## Related Issues and PRs
- Fixes #581
