### PR TITLE
feat: uniffi wrapper for payment preimage

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -803,6 +803,11 @@ interface Bolt12Invoice {
 	sequence<u8> encode();
 };
 
+interface PaymentPreimage {
+	[Throws=NodeError, Name=from_str]
+	constructor([ByRef] string preimage_str);
+};
+
 [Custom]
 typedef string Txid;
 
@@ -829,9 +834,6 @@ typedef string PaymentId;
 
 [Custom]
 typedef string PaymentHash;
-
-[Custom]
-typedef string PaymentPreimage;
 
 [Custom]
 typedef string PaymentSecret;

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -19,7 +19,7 @@ where
 }
 
 #[cfg(feature = "uniffi")]
-pub fn maybe_try_convert_enum<T, R>(wrapped_type: &T) -> Result<R, crate::error::Error>
+pub fn maybe_try_from<T, R>(wrapped_type: &T) -> Result<R, crate::error::Error>
 where
 	for<'a> R: TryFrom<&'a T, Error = crate::error::Error>,
 {
@@ -37,7 +37,7 @@ pub fn maybe_deref<T>(value: &T) -> &T {
 }
 
 #[cfg(not(feature = "uniffi"))]
-pub fn maybe_try_convert_enum<T>(value: &T) -> Result<&T, crate::error::Error> {
+pub fn maybe_try_from<T>(value: &T) -> Result<&T, crate::error::Error> {
 	Ok(value)
 }
 

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -13,7 +13,7 @@ use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::connection::ConnectionManager;
 use crate::data_store::DataStoreUpdateResult;
 use crate::error::Error;
-use crate::ffi::{maybe_deref, maybe_try_convert_enum, maybe_wrap};
+use crate::ffi::{maybe_deref, maybe_try_from, maybe_wrap};
 use crate::liquidity::LiquiditySource;
 use crate::logger::{log_error, log_info, LdkLogger, Logger};
 use crate::payment::store::{
@@ -436,7 +436,7 @@ impl Bolt11Payment {
 	pub fn receive(
 		&self, amount_msat: u64, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice = self.receive_inner(Some(amount_msat), &description, expiry_secs, None)?;
 		Ok(maybe_wrap(invoice))
 	}
@@ -459,7 +459,7 @@ impl Bolt11Payment {
 		&self, amount_msat: u64, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		payment_hash: PaymentHash,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice =
 			self.receive_inner(Some(amount_msat), &description, expiry_secs, Some(payment_hash))?;
 		Ok(maybe_wrap(invoice))
@@ -472,7 +472,7 @@ impl Bolt11Payment {
 	pub fn receive_variable_amount(
 		&self, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice = self.receive_inner(None, &description, expiry_secs, None)?;
 		Ok(maybe_wrap(invoice))
 	}
@@ -494,7 +494,7 @@ impl Bolt11Payment {
 	pub fn receive_variable_amount_for_hash(
 		&self, description: &Bolt11InvoiceDescription, expiry_secs: u32, payment_hash: PaymentHash,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice = self.receive_inner(None, &description, expiry_secs, Some(payment_hash))?;
 		Ok(maybe_wrap(invoice))
 	}
@@ -571,7 +571,7 @@ impl Bolt11Payment {
 		&self, amount_msat: u64, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_total_lsp_fee_limit_msat: Option<u64>,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice = self.receive_via_jit_channel_inner(
 			Some(amount_msat),
 			&description,
@@ -597,7 +597,7 @@ impl Bolt11Payment {
 		&self, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_proportional_lsp_fee_limit_ppm_msat: Option<u64>,
 	) -> Result<Bolt11Invoice, Error> {
-		let description = maybe_try_convert_enum(description)?;
+		let description = maybe_try_from(description)?;
 		let invoice = self.receive_via_jit_channel_inner(
 			None,
 			&description,


### PR DESCRIPTION
## What this PR does
In a bid to create a uniffi wrapper for `PaymentPreimage` as an
interface object, we also create bindings-specific variants for the 
following types:
- `LightningBalance`, 
- `PaymentKind`, and 
- `Event`, 
All of which have fields that hold object/interface instances - 
`PaymentPreimage`, `ConfirmationStatus` and `ClosureReason`.

This is not currently supported in uniffi 0.27.3
```sh
thread 'main' panicked at build.rs:10:59:
  called `Result::unwrap()` on an `Err` value: Objects cannot currently be used in enum variant data
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
    
To workaround this limitation, we `Arc` these types and implement type conversion 
for the new FFI types created.
    
Unfortunately this also does not build. Even though, according to the uniffi docs:
>When you want to ... store object instances as fields in records,
the underlying Rust code will need to work with Arc<T> directly,
to ensure that the code behaves in the way that UniFFI expects.

this `Arc`-ing the fields that hold `PaymentPreimage`, `ConfirmationStatus`,
& `ClosureReason` in the related enums is not sufficient to circumvent 
the error associated with objects not being supported in enum variants.
```sh
Caused by:
  thread 'main' panicked at build.rs:10:59:
  called `Result::unwrap()` on an `Err` value: Objects cannot currently be used in enum variant data
```

## Update
We discover that support for interface in enum variant fields have been added to uniffi 0.30.0
but this upgrade will bring in a significant amount of changes to the entire library, discounting
the boilerplate required to support exposing `PaymentPreimage` to FFI as an interface object.

Following conversations with maintainer, we agree to pause this feature work so that blocked
PRs can move forward. See some related conversation [here](https://github.com/lightningdevkit/ldk-node/pull/549#issuecomment-3023086245).